### PR TITLE
Fix pointers equality in TypeDefinitionsEquivalent function

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"go/token"
 	"net/url"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -864,5 +865,5 @@ func TypeDefinitionsEquivalent(t1, t2 TypeDefinition) bool {
 	if t1.TypeName != t2.TypeName {
 		return false
 	}
-	return t1.Schema.OAPISchema == t2.Schema.OAPISchema
+	return reflect.DeepEqual(t1.Schema.OAPISchema, t2.Schema.OAPISchema)
 }

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -432,3 +432,13 @@ func TestSchemaNameToTypeName(t *testing.T) {
 		assert.Equal(t, want, SchemaNameToTypeName(in))
 	}
 }
+
+func TestTypeDefinitionsEquivalent(t *testing.T) {
+	def1 := TypeDefinition{TypeName: "name", Schema: Schema{
+		OAPISchema: &openapi3.Schema{},
+	}}
+	def2 := TypeDefinition{TypeName: "name", Schema: Schema{
+		OAPISchema: &openapi3.Schema{},
+	}}
+	assert.True(t, TypeDefinitionsEquivalent(def1, def2))
+}


### PR DESCRIPTION
`OAPISchema` is a pointer and using `==` to check the equality of the pointers is always false. The correct way is doing it using `DeepEqual`.